### PR TITLE
Set GPT-4 as a default model

### DIFF
--- a/ansible_lint/rules/gpt.py
+++ b/ansible_lint/rules/gpt.py
@@ -17,7 +17,7 @@ if not os.getenv("OPENAI_API_KEY"):
     )
 
 openai.api_key = os.environ["OPENAI_API_KEY"]
-MODEL = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
+MODEL = os.environ.get("OPENAI_MODEL", "gpt-4")
 TEMPERATURE = os.environ.get("OPENAI_TEMPERATURE", "0.4")
 TOKENS = os.environ.get("OPENAI_TOKENS")
 

--- a/article.md
+++ b/article.md
@@ -21,7 +21,7 @@ The only required parameter for running the OpenAI callback plugin is the OpenAI
 
 The remaining parameters are optional and can be configured according to your needs:
 
-* openai_model - by default `gpt-3.5-turbo` is used (could be set with environment variable `OPENAI_MODEL`)
+* openai_model - by default `gpt-4` is used (could be set with environment variable `OPENAI_MODEL`, for example `gpt-3.5-turbo`)
 * temperature_ai - AI temperature, you can read more about it in [OpenAI docs](https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature) (could be set with environment variable `OPENAI_TEMPERATURE`), by default it's set in OpenAI.
 * tokens_ai - AI max tokens, you can read more about it in [OpenAI docs](https://platform.openai.com/docs/api-reference/completions/create#completions/create-max_tokens) (could be set with environment variable `OPENAI_TOKENS`), by default it's set in OpenAI.
 

--- a/plugins/callback/openai.py
+++ b/plugins/callback/openai.py
@@ -27,7 +27,7 @@ DOCUMENTATION = '''
             key: openai_api_key
       openai_model:
         description: OpenAI model
-        default: gpt-3.5-turbo
+        default: gpt-4
         env:
           - name: OPENAI_MODEL
         ini:


### PR DESCRIPTION
Since it's much more available now, set default model to GPT-4. It's still configurable in OPENAI_MODEL env variable.